### PR TITLE
Update config.h

### DIFF
--- a/examples/MQTTBlinds/config.h
+++ b/examples/MQTTBlinds/config.h
@@ -5,9 +5,13 @@
 #define WIFI_PASSWORD "wifi_password"
 
 // MQTT server details.
-#define MQTT_ADDRESS "192.168.0.88"
+#define MQTT_ADDRESS "192.168.x.x"
 #define MQTT_USERNAME ""
 #define MQTT_PASSWORD ""
+
+// WDT Timeout - comment out if not required
+#define WDT_TIMEOUT 6
+
 
 // Comment below to use the device mac address in the topic instead of the name. Ignored
 // if autodiscovery is enabled (will always use the mac address).
@@ -35,13 +39,20 @@
 // a different MQTT_TOPIC_PREFIX, and use the DEVICE_ALLOWLIST to control up
 // to 3 am43's per ESP.
 //
+
+#define     shade1 "11:22:33:44:55:66"
+#define     shade2 "11:22:33:44:55:66"
+#define     shade3 "11:22:33:44:55:66"
+#define     shade4 "11:22:33:44:55:66"
+
 #define DEVICE_ALLOWLIST ""
 //#define DEVICE_ALLOWLIST "11:22:33:44:55:66"
 //#define DEVICE_ALLOWLIST "11:22:33:44:55:66,AA:BB:CC:DD:EE:FF"
 
+#define DEVICE_ALLOWLIST  shade1 "," shade2
 // Comment out below to disable the OTA feature, especially if you have
 // stability problems.
-#define ENABLE_ARDUINO_OTA
+//#define ENABLE_ARDUINO_OTA
 
 // LEAVE BELOW UNTOUCHED
 #ifdef AM43_ENABLE_MQTT_DISCOVERY


### PR DESCRIPTION
Add in optional WDT timeout parameter
Also added in a few defines for individual motors - to make it easier to keep track of which mac addresses go with each AM43 motor
Also set OTA off by default to help with stability - although haven't tried OTA with WDT turned on